### PR TITLE
feat: display compact message reactions

### DIFF
--- a/packages/flutter_chat_core/lib/src/models/builders.dart
+++ b/packages/flutter_chat_core/lib/src/models/builders.dart
@@ -124,6 +124,14 @@ typedef ScrollToBottomBuilder =
       VoidCallback onPressed,
     );
 
+/// Signature for building the reactions widget rendered below a message.
+typedef MessageReactionsBuilder =
+    Widget? Function(
+      BuildContext,
+      Message message, {
+      required bool isSentByMe,
+    });
+
 /// Signature for building the loading indicator shown when fetching more messages.
 typedef LoadMoreBuilder = Widget Function(BuildContext);
 
@@ -181,6 +189,9 @@ abstract class Builders with _$Builders {
 
     /// Custom builder for the "scroll to bottom" button.
     ScrollToBottomBuilder? scrollToBottomBuilder,
+
+    /// Custom builder for rendering message reactions.
+    MessageReactionsBuilder? messageReactionsBuilder,
 
     /// Custom builder for the load more indicator.
     LoadMoreBuilder? loadMoreBuilder,

--- a/packages/flutter_chat_core/lib/src/models/builders.freezed.dart
+++ b/packages/flutter_chat_core/lib/src/models/builders.freezed.dart
@@ -28,7 +28,8 @@ mixin _$Builders {
  ComposerBuilder? get composerBuilder;/// Custom builder for the wrapper around each chat message.
  ChatMessageBuilder? get chatMessageBuilder;/// Custom builder for the main chat list.
  ChatAnimatedListBuilder? get chatAnimatedListBuilder;/// Custom builder for the "scroll to bottom" button.
- ScrollToBottomBuilder? get scrollToBottomBuilder;/// Custom builder for the load more indicator.
+ ScrollToBottomBuilder? get scrollToBottomBuilder;/// Custom builder for rendering message reactions.
+ MessageReactionsBuilder? get messageReactionsBuilder;/// Custom builder for the load more indicator.
  LoadMoreBuilder? get loadMoreBuilder;/// Custom builder for the empty chat list.
  EmptyChatListBuilder? get emptyChatListBuilder;/// Custom builder for the link preview widget.
  LinkPreviewBuilder? get linkPreviewBuilder;
@@ -41,17 +42,17 @@ $BuildersCopyWith<Builders> get copyWith => _$BuildersCopyWithImpl<Builders>(thi
 
 
 @override
-bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is Builders&&(identical(other.textMessageBuilder, textMessageBuilder) || other.textMessageBuilder == textMessageBuilder)&&(identical(other.textStreamMessageBuilder, textStreamMessageBuilder) || other.textStreamMessageBuilder == textStreamMessageBuilder)&&(identical(other.imageMessageBuilder, imageMessageBuilder) || other.imageMessageBuilder == imageMessageBuilder)&&(identical(other.fileMessageBuilder, fileMessageBuilder) || other.fileMessageBuilder == fileMessageBuilder)&&(identical(other.videoMessageBuilder, videoMessageBuilder) || other.videoMessageBuilder == videoMessageBuilder)&&(identical(other.audioMessageBuilder, audioMessageBuilder) || other.audioMessageBuilder == audioMessageBuilder)&&(identical(other.systemMessageBuilder, systemMessageBuilder) || other.systemMessageBuilder == systemMessageBuilder)&&(identical(other.customMessageBuilder, customMessageBuilder) || other.customMessageBuilder == customMessageBuilder)&&(identical(other.unsupportedMessageBuilder, unsupportedMessageBuilder) || other.unsupportedMessageBuilder == unsupportedMessageBuilder)&&(identical(other.composerBuilder, composerBuilder) || other.composerBuilder == composerBuilder)&&(identical(other.chatMessageBuilder, chatMessageBuilder) || other.chatMessageBuilder == chatMessageBuilder)&&(identical(other.chatAnimatedListBuilder, chatAnimatedListBuilder) || other.chatAnimatedListBuilder == chatAnimatedListBuilder)&&(identical(other.scrollToBottomBuilder, scrollToBottomBuilder) || other.scrollToBottomBuilder == scrollToBottomBuilder)&&(identical(other.loadMoreBuilder, loadMoreBuilder) || other.loadMoreBuilder == loadMoreBuilder)&&(identical(other.emptyChatListBuilder, emptyChatListBuilder) || other.emptyChatListBuilder == emptyChatListBuilder)&&(identical(other.linkPreviewBuilder, linkPreviewBuilder) || other.linkPreviewBuilder == linkPreviewBuilder));
-}
+  bool operator ==(Object other) {
+    return identical(this, other) || (other.runtimeType == runtimeType&&other is Builders&&(identical(other.textMessageBuilder, textMessageBuilder) || other.textMessageBuilder == textMessageBuilder)&&(identical(other.textStreamMessageBuilder, textStreamMessageBuilder) || other.textStreamMessageBuilder == textStreamMessageBuilder)&&(identical(other.imageMessageBuilder, imageMessageBuilder) || other.imageMessageBuilder == imageMessageBuilder)&&(identical(other.fileMessageBuilder, fileMessageBuilder) || other.fileMessageBuilder == fileMessageBuilder)&&(identical(other.videoMessageBuilder, videoMessageBuilder) || other.videoMessageBuilder == videoMessageBuilder)&&(identical(other.audioMessageBuilder, audioMessageBuilder) || other.audioMessageBuilder == audioMessageBuilder)&&(identical(other.systemMessageBuilder, systemMessageBuilder) || other.systemMessageBuilder == systemMessageBuilder)&&(identical(other.customMessageBuilder, customMessageBuilder) || other.customMessageBuilder == customMessageBuilder)&&(identical(other.unsupportedMessageBuilder, unsupportedMessageBuilder) || other.unsupportedMessageBuilder == unsupportedMessageBuilder)&&(identical(other.composerBuilder, composerBuilder) || other.composerBuilder == composerBuilder)&&(identical(other.chatMessageBuilder, chatMessageBuilder) || other.chatMessageBuilder == chatMessageBuilder)&&(identical(other.chatAnimatedListBuilder, chatAnimatedListBuilder) || other.chatAnimatedListBuilder == chatAnimatedListBuilder)&&(identical(other.scrollToBottomBuilder, scrollToBottomBuilder) || other.scrollToBottomBuilder == scrollToBottomBuilder)&&(identical(other.messageReactionsBuilder, messageReactionsBuilder) || other.messageReactionsBuilder == messageReactionsBuilder)&&(identical(other.loadMoreBuilder, loadMoreBuilder) || other.loadMoreBuilder == loadMoreBuilder)&&(identical(other.emptyChatListBuilder, emptyChatListBuilder) || other.emptyChatListBuilder == emptyChatListBuilder)&&(identical(other.linkPreviewBuilder, linkPreviewBuilder) || other.linkPreviewBuilder == linkPreviewBuilder));
+  }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,textMessageBuilder,textStreamMessageBuilder,imageMessageBuilder,fileMessageBuilder,videoMessageBuilder,audioMessageBuilder,systemMessageBuilder,customMessageBuilder,unsupportedMessageBuilder,composerBuilder,chatMessageBuilder,chatAnimatedListBuilder,scrollToBottomBuilder,loadMoreBuilder,emptyChatListBuilder,linkPreviewBuilder);
+  int get hashCode => Object.hash(runtimeType,textMessageBuilder,textStreamMessageBuilder,imageMessageBuilder,fileMessageBuilder,videoMessageBuilder,audioMessageBuilder,systemMessageBuilder,customMessageBuilder,unsupportedMessageBuilder,composerBuilder,chatMessageBuilder,chatAnimatedListBuilder,scrollToBottomBuilder,messageReactionsBuilder,loadMoreBuilder,emptyChatListBuilder,linkPreviewBuilder);
 
 @override
 String toString() {
-  return 'Builders(textMessageBuilder: $textMessageBuilder, textStreamMessageBuilder: $textStreamMessageBuilder, imageMessageBuilder: $imageMessageBuilder, fileMessageBuilder: $fileMessageBuilder, videoMessageBuilder: $videoMessageBuilder, audioMessageBuilder: $audioMessageBuilder, systemMessageBuilder: $systemMessageBuilder, customMessageBuilder: $customMessageBuilder, unsupportedMessageBuilder: $unsupportedMessageBuilder, composerBuilder: $composerBuilder, chatMessageBuilder: $chatMessageBuilder, chatAnimatedListBuilder: $chatAnimatedListBuilder, scrollToBottomBuilder: $scrollToBottomBuilder, loadMoreBuilder: $loadMoreBuilder, emptyChatListBuilder: $emptyChatListBuilder, linkPreviewBuilder: $linkPreviewBuilder)';
+    return 'Builders(textMessageBuilder: $textMessageBuilder, textStreamMessageBuilder: $textStreamMessageBuilder, imageMessageBuilder: $imageMessageBuilder, fileMessageBuilder: $fileMessageBuilder, videoMessageBuilder: $videoMessageBuilder, audioMessageBuilder: $audioMessageBuilder, systemMessageBuilder: $systemMessageBuilder, customMessageBuilder: $customMessageBuilder, unsupportedMessageBuilder: $unsupportedMessageBuilder, composerBuilder: $composerBuilder, chatMessageBuilder: $chatMessageBuilder, chatAnimatedListBuilder: $chatAnimatedListBuilder, scrollToBottomBuilder: $scrollToBottomBuilder, messageReactionsBuilder: $messageReactionsBuilder, loadMoreBuilder: $loadMoreBuilder, emptyChatListBuilder: $emptyChatListBuilder, linkPreviewBuilder: $linkPreviewBuilder)';
 }
 
 
@@ -61,9 +62,9 @@ String toString() {
 abstract mixin class $BuildersCopyWith<$Res>  {
   factory $BuildersCopyWith(Builders value, $Res Function(Builders) _then) = _$BuildersCopyWithImpl;
 @useResult
-$Res call({
- TextMessageBuilder? textMessageBuilder, TextStreamMessageBuilder? textStreamMessageBuilder, ImageMessageBuilder? imageMessageBuilder, FileMessageBuilder? fileMessageBuilder, VideoMessageBuilder? videoMessageBuilder, AudioMessageBuilder? audioMessageBuilder, SystemMessageBuilder? systemMessageBuilder, CustomMessageBuilder? customMessageBuilder, UnsupportedMessageBuilder? unsupportedMessageBuilder, ComposerBuilder? composerBuilder, ChatMessageBuilder? chatMessageBuilder, ChatAnimatedListBuilder? chatAnimatedListBuilder, ScrollToBottomBuilder? scrollToBottomBuilder, LoadMoreBuilder? loadMoreBuilder, EmptyChatListBuilder? emptyChatListBuilder, LinkPreviewBuilder? linkPreviewBuilder
-});
+ $Res call({
+  TextMessageBuilder? textMessageBuilder, TextStreamMessageBuilder? textStreamMessageBuilder, ImageMessageBuilder? imageMessageBuilder, FileMessageBuilder? fileMessageBuilder, VideoMessageBuilder? videoMessageBuilder, AudioMessageBuilder? audioMessageBuilder, SystemMessageBuilder? systemMessageBuilder, CustomMessageBuilder? customMessageBuilder, UnsupportedMessageBuilder? unsupportedMessageBuilder, ComposerBuilder? composerBuilder, ChatMessageBuilder? chatMessageBuilder, ChatAnimatedListBuilder? chatAnimatedListBuilder, ScrollToBottomBuilder? scrollToBottomBuilder, MessageReactionsBuilder? messageReactionsBuilder, LoadMoreBuilder? loadMoreBuilder, EmptyChatListBuilder? emptyChatListBuilder, LinkPreviewBuilder? linkPreviewBuilder
+ });
 
 
 
@@ -79,7 +80,7 @@ class _$BuildersCopyWithImpl<$Res>
 
 /// Create a copy of Builders
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? textMessageBuilder = freezed,Object? textStreamMessageBuilder = freezed,Object? imageMessageBuilder = freezed,Object? fileMessageBuilder = freezed,Object? videoMessageBuilder = freezed,Object? audioMessageBuilder = freezed,Object? systemMessageBuilder = freezed,Object? customMessageBuilder = freezed,Object? unsupportedMessageBuilder = freezed,Object? composerBuilder = freezed,Object? chatMessageBuilder = freezed,Object? chatAnimatedListBuilder = freezed,Object? scrollToBottomBuilder = freezed,Object? loadMoreBuilder = freezed,Object? emptyChatListBuilder = freezed,Object? linkPreviewBuilder = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? textMessageBuilder = freezed,Object? textStreamMessageBuilder = freezed,Object? imageMessageBuilder = freezed,Object? fileMessageBuilder = freezed,Object? videoMessageBuilder = freezed,Object? audioMessageBuilder = freezed,Object? systemMessageBuilder = freezed,Object? customMessageBuilder = freezed,Object? unsupportedMessageBuilder = freezed,Object? composerBuilder = freezed,Object? chatMessageBuilder = freezed,Object? chatAnimatedListBuilder = freezed,Object? scrollToBottomBuilder = freezed,Object? messageReactionsBuilder = freezed,Object? loadMoreBuilder = freezed,Object? emptyChatListBuilder = freezed,Object? linkPreviewBuilder = freezed,}) {
   return _then(_self.copyWith(
 textMessageBuilder: freezed == textMessageBuilder ? _self.textMessageBuilder : textMessageBuilder // ignore: cast_nullable_to_non_nullable
 as TextMessageBuilder?,textStreamMessageBuilder: freezed == textStreamMessageBuilder ? _self.textStreamMessageBuilder : textStreamMessageBuilder // ignore: cast_nullable_to_non_nullable
@@ -94,7 +95,8 @@ as UnsupportedMessageBuilder?,composerBuilder: freezed == composerBuilder ? _sel
 as ComposerBuilder?,chatMessageBuilder: freezed == chatMessageBuilder ? _self.chatMessageBuilder : chatMessageBuilder // ignore: cast_nullable_to_non_nullable
 as ChatMessageBuilder?,chatAnimatedListBuilder: freezed == chatAnimatedListBuilder ? _self.chatAnimatedListBuilder : chatAnimatedListBuilder // ignore: cast_nullable_to_non_nullable
 as ChatAnimatedListBuilder?,scrollToBottomBuilder: freezed == scrollToBottomBuilder ? _self.scrollToBottomBuilder : scrollToBottomBuilder // ignore: cast_nullable_to_non_nullable
-as ScrollToBottomBuilder?,loadMoreBuilder: freezed == loadMoreBuilder ? _self.loadMoreBuilder : loadMoreBuilder // ignore: cast_nullable_to_non_nullable
+as ScrollToBottomBuilder?,messageReactionsBuilder: freezed == messageReactionsBuilder ? _self.messageReactionsBuilder : messageReactionsBuilder // ignore: cast_nullable_to_non_nullable
+  as MessageReactionsBuilder?,loadMoreBuilder: freezed == loadMoreBuilder ? _self.loadMoreBuilder : loadMoreBuilder // ignore: cast_nullable_to_non_nullable
 as LoadMoreBuilder?,emptyChatListBuilder: freezed == emptyChatListBuilder ? _self.emptyChatListBuilder : emptyChatListBuilder // ignore: cast_nullable_to_non_nullable
 as EmptyChatListBuilder?,linkPreviewBuilder: freezed == linkPreviewBuilder ? _self.linkPreviewBuilder : linkPreviewBuilder // ignore: cast_nullable_to_non_nullable
 as LinkPreviewBuilder?,
@@ -108,7 +110,7 @@ as LinkPreviewBuilder?,
 
 
 class _Builders extends Builders {
-  const _Builders({this.textMessageBuilder, this.textStreamMessageBuilder, this.imageMessageBuilder, this.fileMessageBuilder, this.videoMessageBuilder, this.audioMessageBuilder, this.systemMessageBuilder, this.customMessageBuilder, this.unsupportedMessageBuilder, this.composerBuilder, this.chatMessageBuilder, this.chatAnimatedListBuilder, this.scrollToBottomBuilder, this.loadMoreBuilder, this.emptyChatListBuilder, this.linkPreviewBuilder}): super._();
+  const _Builders({this.textMessageBuilder, this.textStreamMessageBuilder, this.imageMessageBuilder, this.fileMessageBuilder, this.videoMessageBuilder, this.audioMessageBuilder, this.systemMessageBuilder, this.customMessageBuilder, this.unsupportedMessageBuilder, this.composerBuilder, this.chatMessageBuilder, this.chatAnimatedListBuilder, this.scrollToBottomBuilder, this.messageReactionsBuilder, this.loadMoreBuilder, this.emptyChatListBuilder, this.linkPreviewBuilder}): super._();
   
 
 /// Custom builder for text messages.
@@ -137,6 +139,8 @@ class _Builders extends Builders {
 @override final  ChatAnimatedListBuilder? chatAnimatedListBuilder;
 /// Custom builder for the "scroll to bottom" button.
 @override final  ScrollToBottomBuilder? scrollToBottomBuilder;
+/// Custom builder for rendering message reactions.
+@override final  MessageReactionsBuilder? messageReactionsBuilder;
 /// Custom builder for the load more indicator.
 @override final  LoadMoreBuilder? loadMoreBuilder;
 /// Custom builder for the empty chat list.
@@ -153,17 +157,17 @@ _$BuildersCopyWith<_Builders> get copyWith => __$BuildersCopyWithImpl<_Builders>
 
 
 @override
-bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Builders&&(identical(other.textMessageBuilder, textMessageBuilder) || other.textMessageBuilder == textMessageBuilder)&&(identical(other.textStreamMessageBuilder, textStreamMessageBuilder) || other.textStreamMessageBuilder == textStreamMessageBuilder)&&(identical(other.imageMessageBuilder, imageMessageBuilder) || other.imageMessageBuilder == imageMessageBuilder)&&(identical(other.fileMessageBuilder, fileMessageBuilder) || other.fileMessageBuilder == fileMessageBuilder)&&(identical(other.videoMessageBuilder, videoMessageBuilder) || other.videoMessageBuilder == videoMessageBuilder)&&(identical(other.audioMessageBuilder, audioMessageBuilder) || other.audioMessageBuilder == audioMessageBuilder)&&(identical(other.systemMessageBuilder, systemMessageBuilder) || other.systemMessageBuilder == systemMessageBuilder)&&(identical(other.customMessageBuilder, customMessageBuilder) || other.customMessageBuilder == customMessageBuilder)&&(identical(other.unsupportedMessageBuilder, unsupportedMessageBuilder) || other.unsupportedMessageBuilder == unsupportedMessageBuilder)&&(identical(other.composerBuilder, composerBuilder) || other.composerBuilder == composerBuilder)&&(identical(other.chatMessageBuilder, chatMessageBuilder) || other.chatMessageBuilder == chatMessageBuilder)&&(identical(other.chatAnimatedListBuilder, chatAnimatedListBuilder) || other.chatAnimatedListBuilder == chatAnimatedListBuilder)&&(identical(other.scrollToBottomBuilder, scrollToBottomBuilder) || other.scrollToBottomBuilder == scrollToBottomBuilder)&&(identical(other.loadMoreBuilder, loadMoreBuilder) || other.loadMoreBuilder == loadMoreBuilder)&&(identical(other.emptyChatListBuilder, emptyChatListBuilder) || other.emptyChatListBuilder == emptyChatListBuilder)&&(identical(other.linkPreviewBuilder, linkPreviewBuilder) || other.linkPreviewBuilder == linkPreviewBuilder));
-}
+  bool operator ==(Object other) {
+    return identical(this, other) || (other.runtimeType == runtimeType&&other is _Builders&&(identical(other.textMessageBuilder, textMessageBuilder) || other.textMessageBuilder == textMessageBuilder)&&(identical(other.textStreamMessageBuilder, textStreamMessageBuilder) || other.textStreamMessageBuilder == textStreamMessageBuilder)&&(identical(other.imageMessageBuilder, imageMessageBuilder) || other.imageMessageBuilder == imageMessageBuilder)&&(identical(other.fileMessageBuilder, fileMessageBuilder) || other.fileMessageBuilder == fileMessageBuilder)&&(identical(other.videoMessageBuilder, videoMessageBuilder) || other.videoMessageBuilder == videoMessageBuilder)&&(identical(other.audioMessageBuilder, audioMessageBuilder) || other.audioMessageBuilder == audioMessageBuilder)&&(identical(other.systemMessageBuilder, systemMessageBuilder) || other.systemMessageBuilder == systemMessageBuilder)&&(identical(other.customMessageBuilder, customMessageBuilder) || other.customMessageBuilder == customMessageBuilder)&&(identical(other.unsupportedMessageBuilder, unsupportedMessageBuilder) || other.unsupportedMessageBuilder == unsupportedMessageBuilder)&&(identical(other.composerBuilder, composerBuilder) || other.composerBuilder == composerBuilder)&&(identical(other.chatMessageBuilder, chatMessageBuilder) || other.chatMessageBuilder == chatMessageBuilder)&&(identical(other.chatAnimatedListBuilder, chatAnimatedListBuilder) || other.chatAnimatedListBuilder == chatAnimatedListBuilder)&&(identical(other.scrollToBottomBuilder, scrollToBottomBuilder) || other.scrollToBottomBuilder == scrollToBottomBuilder)&&(identical(other.messageReactionsBuilder, messageReactionsBuilder) || other.messageReactionsBuilder == messageReactionsBuilder)&&(identical(other.loadMoreBuilder, loadMoreBuilder) || other.loadMoreBuilder == loadMoreBuilder)&&(identical(other.emptyChatListBuilder, emptyChatListBuilder) || other.emptyChatListBuilder == emptyChatListBuilder)&&(identical(other.linkPreviewBuilder, linkPreviewBuilder) || other.linkPreviewBuilder == linkPreviewBuilder));
+  }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,textMessageBuilder,textStreamMessageBuilder,imageMessageBuilder,fileMessageBuilder,videoMessageBuilder,audioMessageBuilder,systemMessageBuilder,customMessageBuilder,unsupportedMessageBuilder,composerBuilder,chatMessageBuilder,chatAnimatedListBuilder,scrollToBottomBuilder,loadMoreBuilder,emptyChatListBuilder,linkPreviewBuilder);
+  int get hashCode => Object.hash(runtimeType,textMessageBuilder,textStreamMessageBuilder,imageMessageBuilder,fileMessageBuilder,videoMessageBuilder,audioMessageBuilder,systemMessageBuilder,customMessageBuilder,unsupportedMessageBuilder,composerBuilder,chatMessageBuilder,chatAnimatedListBuilder,scrollToBottomBuilder,messageReactionsBuilder,loadMoreBuilder,emptyChatListBuilder,linkPreviewBuilder);
 
 @override
 String toString() {
-  return 'Builders(textMessageBuilder: $textMessageBuilder, textStreamMessageBuilder: $textStreamMessageBuilder, imageMessageBuilder: $imageMessageBuilder, fileMessageBuilder: $fileMessageBuilder, videoMessageBuilder: $videoMessageBuilder, audioMessageBuilder: $audioMessageBuilder, systemMessageBuilder: $systemMessageBuilder, customMessageBuilder: $customMessageBuilder, unsupportedMessageBuilder: $unsupportedMessageBuilder, composerBuilder: $composerBuilder, chatMessageBuilder: $chatMessageBuilder, chatAnimatedListBuilder: $chatAnimatedListBuilder, scrollToBottomBuilder: $scrollToBottomBuilder, loadMoreBuilder: $loadMoreBuilder, emptyChatListBuilder: $emptyChatListBuilder, linkPreviewBuilder: $linkPreviewBuilder)';
+    return 'Builders(textMessageBuilder: $textMessageBuilder, textStreamMessageBuilder: $textStreamMessageBuilder, imageMessageBuilder: $imageMessageBuilder, fileMessageBuilder: $fileMessageBuilder, videoMessageBuilder: $videoMessageBuilder, audioMessageBuilder: $audioMessageBuilder, systemMessageBuilder: $systemMessageBuilder, customMessageBuilder: $customMessageBuilder, unsupportedMessageBuilder: $unsupportedMessageBuilder, composerBuilder: $composerBuilder, chatMessageBuilder: $chatMessageBuilder, chatAnimatedListBuilder: $chatAnimatedListBuilder, scrollToBottomBuilder: $scrollToBottomBuilder, messageReactionsBuilder: $messageReactionsBuilder, loadMoreBuilder: $loadMoreBuilder, emptyChatListBuilder: $emptyChatListBuilder, linkPreviewBuilder: $linkPreviewBuilder)';
 }
 
 
@@ -173,9 +177,9 @@ String toString() {
 abstract mixin class _$BuildersCopyWith<$Res> implements $BuildersCopyWith<$Res> {
   factory _$BuildersCopyWith(_Builders value, $Res Function(_Builders) _then) = __$BuildersCopyWithImpl;
 @override @useResult
-$Res call({
- TextMessageBuilder? textMessageBuilder, TextStreamMessageBuilder? textStreamMessageBuilder, ImageMessageBuilder? imageMessageBuilder, FileMessageBuilder? fileMessageBuilder, VideoMessageBuilder? videoMessageBuilder, AudioMessageBuilder? audioMessageBuilder, SystemMessageBuilder? systemMessageBuilder, CustomMessageBuilder? customMessageBuilder, UnsupportedMessageBuilder? unsupportedMessageBuilder, ComposerBuilder? composerBuilder, ChatMessageBuilder? chatMessageBuilder, ChatAnimatedListBuilder? chatAnimatedListBuilder, ScrollToBottomBuilder? scrollToBottomBuilder, LoadMoreBuilder? loadMoreBuilder, EmptyChatListBuilder? emptyChatListBuilder, LinkPreviewBuilder? linkPreviewBuilder
-});
+ $Res call({
+  TextMessageBuilder? textMessageBuilder, TextStreamMessageBuilder? textStreamMessageBuilder, ImageMessageBuilder? imageMessageBuilder, FileMessageBuilder? fileMessageBuilder, VideoMessageBuilder? videoMessageBuilder, AudioMessageBuilder? audioMessageBuilder, SystemMessageBuilder? systemMessageBuilder, CustomMessageBuilder? customMessageBuilder, UnsupportedMessageBuilder? unsupportedMessageBuilder, ComposerBuilder? composerBuilder, ChatMessageBuilder? chatMessageBuilder, ChatAnimatedListBuilder? chatAnimatedListBuilder, ScrollToBottomBuilder? scrollToBottomBuilder, MessageReactionsBuilder? messageReactionsBuilder, LoadMoreBuilder? loadMoreBuilder, EmptyChatListBuilder? emptyChatListBuilder, LinkPreviewBuilder? linkPreviewBuilder
+ });
 
 
 
@@ -191,7 +195,7 @@ class __$BuildersCopyWithImpl<$Res>
 
 /// Create a copy of Builders
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? textMessageBuilder = freezed,Object? textStreamMessageBuilder = freezed,Object? imageMessageBuilder = freezed,Object? fileMessageBuilder = freezed,Object? videoMessageBuilder = freezed,Object? audioMessageBuilder = freezed,Object? systemMessageBuilder = freezed,Object? customMessageBuilder = freezed,Object? unsupportedMessageBuilder = freezed,Object? composerBuilder = freezed,Object? chatMessageBuilder = freezed,Object? chatAnimatedListBuilder = freezed,Object? scrollToBottomBuilder = freezed,Object? loadMoreBuilder = freezed,Object? emptyChatListBuilder = freezed,Object? linkPreviewBuilder = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? textMessageBuilder = freezed,Object? textStreamMessageBuilder = freezed,Object? imageMessageBuilder = freezed,Object? fileMessageBuilder = freezed,Object? videoMessageBuilder = freezed,Object? audioMessageBuilder = freezed,Object? systemMessageBuilder = freezed,Object? customMessageBuilder = freezed,Object? unsupportedMessageBuilder = freezed,Object? composerBuilder = freezed,Object? chatMessageBuilder = freezed,Object? chatAnimatedListBuilder = freezed,Object? scrollToBottomBuilder = freezed,Object? messageReactionsBuilder = freezed,Object? loadMoreBuilder = freezed,Object? emptyChatListBuilder = freezed,Object? linkPreviewBuilder = freezed,}) {
   return _then(_Builders(
 textMessageBuilder: freezed == textMessageBuilder ? _self.textMessageBuilder : textMessageBuilder // ignore: cast_nullable_to_non_nullable
 as TextMessageBuilder?,textStreamMessageBuilder: freezed == textStreamMessageBuilder ? _self.textStreamMessageBuilder : textStreamMessageBuilder // ignore: cast_nullable_to_non_nullable
@@ -206,7 +210,8 @@ as UnsupportedMessageBuilder?,composerBuilder: freezed == composerBuilder ? _sel
 as ComposerBuilder?,chatMessageBuilder: freezed == chatMessageBuilder ? _self.chatMessageBuilder : chatMessageBuilder // ignore: cast_nullable_to_non_nullable
 as ChatMessageBuilder?,chatAnimatedListBuilder: freezed == chatAnimatedListBuilder ? _self.chatAnimatedListBuilder : chatAnimatedListBuilder // ignore: cast_nullable_to_non_nullable
 as ChatAnimatedListBuilder?,scrollToBottomBuilder: freezed == scrollToBottomBuilder ? _self.scrollToBottomBuilder : scrollToBottomBuilder // ignore: cast_nullable_to_non_nullable
-as ScrollToBottomBuilder?,loadMoreBuilder: freezed == loadMoreBuilder ? _self.loadMoreBuilder : loadMoreBuilder // ignore: cast_nullable_to_non_nullable
+as ScrollToBottomBuilder?,messageReactionsBuilder: freezed == messageReactionsBuilder ? _self.messageReactionsBuilder : messageReactionsBuilder // ignore: cast_nullable_to_non_nullable
+  as MessageReactionsBuilder?,loadMoreBuilder: freezed == loadMoreBuilder ? _self.loadMoreBuilder : loadMoreBuilder // ignore: cast_nullable_to_non_nullable
 as LoadMoreBuilder?,emptyChatListBuilder: freezed == emptyChatListBuilder ? _self.emptyChatListBuilder : emptyChatListBuilder // ignore: cast_nullable_to_non_nullable
 as EmptyChatListBuilder?,linkPreviewBuilder: freezed == linkPreviewBuilder ? _self.linkPreviewBuilder : linkPreviewBuilder // ignore: cast_nullable_to_non_nullable
 as LinkPreviewBuilder?,

--- a/packages/flutter_chat_ui/lib/src/chat_message/chat_message_internal.dart
+++ b/packages/flutter_chat_ui/lib/src/chat_message/chat_message_internal.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_chat_core/flutter_chat_core.dart';
+import 'package:flyer_chat_reactions/flyer_chat_reactions.dart';
 import 'package:provider/provider.dart';
 
 import '../simple_text_message.dart';
@@ -99,6 +100,13 @@ class _ChatMessageInternalState extends State<ChatMessageInternal> {
 
     final groupStatus = _resolveGroupStatus(context);
 
+    final reactionsWidget = _buildMessageReactions(
+      context,
+      builders,
+      _updatedMessage,
+      isSentByMe: isSentByMe,
+    );
+
     final child = _buildMessage(
       context,
       builders,
@@ -124,8 +132,110 @@ class _ChatMessageInternalState extends State<ChatMessageInternal> {
           animation: widget.animation,
           isRemoved: widget.isRemoved,
           groupStatus: groupStatus,
+          bottomWidget: reactionsWidget,
           child: child,
         );
+  }
+
+  Widget? _buildMessageReactions(
+    BuildContext context,
+    Builders builders,
+    Message message, {
+    required bool isSentByMe,
+  }) {
+    final rawReactions = _resolveReactions(message);
+    if (rawReactions == null || rawReactions.isEmpty) {
+      return null;
+    }
+
+    if (builders.messageReactionsBuilder case final reactionBuilder?) {
+      final custom = reactionBuilder(
+        context,
+        message,
+        isSentByMe: isSentByMe,
+      );
+      if (custom != null) {
+        return custom;
+      }
+    }
+
+    final normalized = _normalizeReactions(rawReactions);
+    if (normalized.isEmpty) {
+      return null;
+    }
+
+    return FlyerChatMessageReactions(
+      reactions: normalized,
+      isSentByMe: isSentByMe,
+    );
+  }
+
+  Map<String, List<Object?>>? _resolveReactions(Message message) {
+    return switch (message) {
+      TextMessage(:final reactions?) => _castReactions(reactions),
+      TextStreamMessage(:final reactions?) => _castReactions(reactions),
+      ImageMessage(:final reactions?) => _castReactions(reactions),
+      FileMessage(:final reactions?) => _castReactions(reactions),
+      VideoMessage(:final reactions?) => _castReactions(reactions),
+      AudioMessage(:final reactions?) => _castReactions(reactions),
+      SystemMessage(:final reactions?) => _castReactions(reactions),
+      CustomMessage(:final reactions?) => _castReactions(reactions),
+      UnsupportedMessage(:final reactions?) => _castReactions(reactions),
+    };
+  }
+
+  Map<String, List<Object?>> _castReactions<T>(
+    Map<String, List<T>> reactions,
+  ) {
+    return reactions.map(
+      (key, value) => MapEntry(key, List<Object?>.from(value)),
+    );
+  }
+
+  List<FlyerChatReaction> _normalizeReactions(
+    Map<String, List<Object?>> reactions,
+  ) {
+    final result = <FlyerChatReaction>[];
+
+    reactions.forEach((emoji, users) {
+      final trimmedEmoji = emoji.trim();
+      if (trimmedEmoji.isEmpty) {
+        return;
+      }
+
+      final uniqueUsers = <String>{};
+      for (final user in users) {
+        if (user == null) {
+          continue;
+        }
+        final id = user.toString().trim();
+        if (id.isEmpty) {
+          continue;
+        }
+        uniqueUsers.add(id);
+      }
+
+      if (uniqueUsers.isEmpty) {
+        return;
+      }
+
+      result.add(
+        FlyerChatReaction(
+          emoji: trimmedEmoji,
+          count: uniqueUsers.length,
+        ),
+      );
+    });
+
+    result.sort((a, b) {
+      final countCompare = b.count.compareTo(a.count);
+      if (countCompare != 0) {
+        return countCompare;
+      }
+      return a.emoji.compareTo(b.emoji);
+    });
+
+    return result;
   }
 
   MessageGroupStatus? _resolveGroupStatus(BuildContext context) {

--- a/packages/flyer_chat_reactions/lib/flyer_chat_reactions.dart
+++ b/packages/flyer_chat_reactions/lib/flyer_chat_reactions.dart
@@ -1,0 +1,4 @@
+/// Flyer Chat Reactions package. Provides widgets to display message reactions.
+library;
+
+export 'src/flyer_chat_message_reactions.dart';

--- a/packages/flyer_chat_reactions/lib/src/flyer_chat_message_reactions.dart
+++ b/packages/flyer_chat_reactions/lib/src/flyer_chat_message_reactions.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_chat_core/flutter_chat_core.dart';
+import 'package:provider/provider.dart';
+
+/// Represents a single reaction entry with an emoji and reaction count.
+class FlyerChatReaction {
+  /// Creates a reaction entry with the provided [emoji] and number of [count].
+  const FlyerChatReaction({
+    required this.emoji,
+    required this.count,
+  });
+
+  /// The emoji or reaction identifier to display.
+  final String emoji;
+
+  /// Number of unique reactions for the [emoji].
+  final int count;
+}
+
+/// Displays reactions for a chat message using Flyer Chat theming.
+class FlyerChatMessageReactions extends StatelessWidget {
+  /// Creates a widget that renders message reactions within a styled container.
+  const FlyerChatMessageReactions({
+    super.key,
+    required this.reactions,
+    this.isSentByMe = false,
+    this.padding = const EdgeInsets.only(top: 6),
+    this.borderRadius = const BorderRadius.all(Radius.circular(16)),
+  });
+
+  /// Normalized list of reactions to render.
+  final List<FlyerChatReaction> reactions;
+
+  /// Indicates whether the message belongs to the current user.
+  final bool isSentByMe;
+
+  /// Outer padding for the reactions container.
+  final EdgeInsetsGeometry padding;
+
+  /// Border radius of the reactions container.
+  final BorderRadiusGeometry borderRadius;
+
+  @override
+  Widget build(BuildContext context) {
+    if (reactions.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    final theme = context.select(
+      (ChatTheme t) => (
+        background: t.colors.surface,
+        borderColor: t.colors.surfaceContainerHigh,
+        textStyle: t.typography.labelMedium.copyWith(
+          color: t.colors.onSurface,
+        ),
+        emojiStyle: t.typography.bodyLarge,
+      ),
+    );
+
+    final displayed = reactions.take(2).toList();
+    final totalCount = reactions.fold<int>(0, (value, element) => value + element.count);
+    final showCount = totalCount > 1;
+
+    final children = <Widget>[
+      for (final reaction in displayed)
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 2),
+          child: Text(
+            reaction.emoji,
+            style: theme.emojiStyle,
+          ),
+        ),
+    ];
+
+    if (showCount) {
+      if (children.isNotEmpty) {
+        children.add(const SizedBox(width: 4));
+      }
+      children.add(Text(totalCount.toString(), style: theme.textStyle));
+    }
+
+    return Padding(
+      padding: padding,
+      child: Align(
+        alignment: isSentByMe
+            ? AlignmentDirectional.centerEnd
+            : AlignmentDirectional.centerStart,
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            color: theme.background,
+            borderRadius: borderRadius,
+            border: Border.all(color: theme.borderColor),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: children,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/flyer_chat_reactions/pubspec.yaml
+++ b/packages/flyer_chat_reactions/pubspec.yaml
@@ -1,8 +1,7 @@
-name: flutter_chat_ui
-version: 2.9.0
+name: flyer_chat_reactions
+version: 0.1.0
 description: >
-  Free and open-source chat SDK. Build fast, real-time apps and generative
-  AI agents with a high-performance, customizable, cross-platform UI.
+  Reaction bubble widgets for Flyer Chat UI components. #chat #ui
 homepage: https://flyer.chat
 repository: https://github.com/flyerhq/flutter_chat_ui
 
@@ -11,15 +10,10 @@ environment:
   flutter: ">=3.29.0"
 
 dependencies:
-  cross_cache: ^1.0.4
-  diffutil_dart: ^4.0.1
   flutter:
     sdk: flutter
   flutter_chat_core: ^2.8.0
-  flyer_chat_reactions:
-    path: ../flyer_chat_reactions
   provider: ^6.1.5
-  scrollview_observer: ^1.26.1
 
 dev_dependencies:
   flutter_lints: ^6.0.0


### PR DESCRIPTION
## Summary
- add a reusable flyer_chat_reactions package with a default reaction bubble widget
- expose a messageReactionsBuilder hook and wire ChatMessageInternal to render reactions under each message
- pull the new package into flutter_chat_ui so reactions appear with a compact two-emoji layout and count

## Testing
- not run (Flutter SDK is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e4b09197a4832cab0f0553cb2dd7a6